### PR TITLE
Escape limit and tags when passing them to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,10 @@ else # Handle vault password if any
   opts     ?= $(args) --vault-password-file=pass.sh
 endif
 ifneq ("$(limit)", "")
-  opts     := $(opts) --limit $(limit)
+  opts     := $(opts) --limit="$(limit)"
 endif
 ifneq ("$(tag)", "")
-  opts     := $(opts) --tag $(tag)
+  opts     := $(opts) --tag="$(tag)"
 endif
 
 ##


### PR DESCRIPTION
If the argument is not escaped, when using a wildcard:
- if no files matches the pattern with the wildcard,
  bash passes the pattern with the wildcard, it works as expeceted
- if at least one file matches the pattern,
  bash replaces the pattern with the list of files that match it.
  --limit=sql* will be replaced by --limit="sql4.example.net sql5.example.net"

When using --limit="sql*", bash will not interpret the pattern and will pass it as is.