### PR TITLE
deploy: fusion packaging and deployment jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,12 @@ jobs:
     - ansible --version
     script:
     - ./test.sh
-  - stage: package
+  - stage: "package:deploy"
     install:
     - gem install fpm
     script:
     - fpm -s dir -x providers -x .git -t deb -n ansible-make -v $(cat VERSION) ansible-make=/usr/local/bin/
       Makefile=/opt/ansible/ pass.sh=/opt/ansible/
-  - stage: deploy
-    script: skip
     deploy:
       provider: releases
       api_key:


### PR DESCRIPTION
Travis doesn't support easily passing artifacts between jobs (you need
to use "S3 upload artifacts" feature for that).

This is why we fusion both packaging and deployment